### PR TITLE
Add run-all script

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,14 @@ Em outro terminal, execute os testes:
 npm test
 ```
 
+### Script único
+
+Para realizar a build, subir o servidor e rodar os testes de uma só vez:
+
+```bash
+npm run run:all
+```
+
 Para abrir a interface interativa do Cypress:
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "cy:open": "cypress open",
     "cy:run": "cypress run",
     "test": "npm run cy:run",
-    "build": "tsc"
+    "build": "tsc",
+    "run:all": "./run-all.sh"
   },
   "keywords": [],
   "author": "",

--- a/run-all.sh
+++ b/run-all.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -e
+
+# Install dependencies if node_modules does not exist
+if [ ! -d node_modules ]; then
+  echo "Installing dependencies..."
+  npm install
+fi
+
+# Compile TypeScript
+npm run build
+
+# Start the server in background
+node dist/server.js &
+SERVER_PID=$!
+
+# Ensure the server is stopped on exit
+trap 'kill $SERVER_PID' EXIT
+
+# Wait a moment for the server to be ready
+sleep 2
+
+# Run Cypress tests
+npm test


### PR DESCRIPTION
## Summary
- add script run-all.sh to install deps, build, start server, and run tests
- expose run:all npm command
- mention the new script in README

## Testing
- `npm test` *(fails: missing Xvfb)*

------
https://chatgpt.com/codex/tasks/task_e_684238dd36c8832ca791125b7e0a9865