### PR TITLE
Fix static path for example server

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -6,7 +6,9 @@ const PORT = process.env.PORT || 3000;
 
 const server = http.createServer((req, res) => {
   const file = req.url === '/' ? '/index.html' : req.url!;
-  const filePath = path.join(__dirname, 'public', file);
+  // __dirname points to the compiled `dist` folder. The static files live in
+  // `public` at the project root, so go one level up from `dist`.
+  const filePath = path.join(__dirname, '../public', file);
   fs.readFile(filePath, (err, data) => {
     if (err) {
       res.writeHead(404);


### PR DESCRIPTION
## Summary
- correct the path to the `public` folder when serving files from the built server

## Testing
- `npm run run:all`


------
https://chatgpt.com/codex/tasks/task_e_684239ea073c832c9a778326cd270652