### PR TITLE
Add JWT injection example

### DIFF
--- a/cypress/e2e/jwt.feature
+++ b/cypress/e2e/jwt.feature
@@ -1,0 +1,5 @@
+Feature: JWT Token Injection
+  Scenario: Set token before the page loads
+    Given I open the demo page injecting a JWT
+    Then the token property should exist on the body
+    And I can call the generateJWT function later

--- a/cypress/e2e/jwt.ts
+++ b/cypress/e2e/jwt.ts
@@ -1,0 +1,43 @@
+import { Given, Then } from '@badeball/cypress-cucumber-preprocessor';
+
+interface TestWindow extends Window {
+  generateJWT: () => string;
+}
+
+let injectedToken: string;
+
+const attachGenerateJWT = (win: TestWindow) => {
+  win.generateJWT = () => {
+    const header = btoa(JSON.stringify({ alg: 'HS256', typ: 'JWT' }));
+    const payload = btoa(
+      JSON.stringify({ user: 'demo', iat: Math.floor(Date.now() / 1000) })
+    );
+    const signature = btoa('secret');
+    return `${header}.${payload}.${signature}`;
+  };
+};
+
+Given('I open the demo page injecting a JWT', () => {
+  cy.visit('/', {
+    onBeforeLoad(win) {
+      const w = win as unknown as TestWindow;
+      attachGenerateJWT(w);
+      injectedToken = w.generateJWT();
+      (w.document.body as any).token = injectedToken;
+    },
+  });
+});
+
+Then('the token property should exist on the body', () => {
+  cy.get('body').should(($body) => {
+    expect(($body.get(0) as any).token).to.equal(injectedToken);
+  });
+});
+
+Then('I can call the generateJWT function later', () => {
+  cy.window().then((win) => {
+    const w = win as unknown as TestWindow;
+    const newToken = w.generateJWT();
+    expect(newToken).to.be.a('string');
+  });
+});

--- a/public/index.html
+++ b/public/index.html
@@ -7,6 +7,7 @@
 <body>
   <h1 id="title">Hello Cypress</h1>
   <button id="change">Change</button>
+  <p id="token"></p>
   <script src="script.js"></script>
 </body>
 </html>

--- a/public/script.js
+++ b/public/script.js
@@ -1,3 +1,19 @@
-document.getElementById('change').addEventListener('click', () => {
-  document.getElementById('title').textContent = 'Button Clicked';
+window.generateJWT = function () {
+  const header = btoa(JSON.stringify({ alg: 'HS256', typ: 'JWT' }));
+  const payload = btoa(
+    JSON.stringify({ user: 'demo', iat: Math.floor(Date.now() / 1000) })
+  );
+  const signature = btoa('secret');
+  return `${header}.${payload}.${signature}`;
+};
+
+document.addEventListener('DOMContentLoaded', () => {
+  const tokenEl = document.getElementById('token');
+  if (tokenEl) {
+    tokenEl.textContent = document.body.token || '';
+  }
+
+  document.getElementById('change')?.addEventListener('click', () => {
+    document.getElementById('title')!.textContent = 'Button Clicked';
+  });
 });


### PR DESCRIPTION
## Summary
- generate JWT in the browser and expose a helper
- display the token on the demo page
- test injecting the token before the page loads

## Testing
- `npm run build`
- `npm test` *(fails: Xvfb missing)*

------
https://chatgpt.com/codex/tasks/task_e_6842533b043c832cb571d96b6219382d