### PR TITLE
Fix script syntax and jwt test

### DIFF
--- a/cypress/e2e/jwt.ts
+++ b/cypress/e2e/jwt.ts
@@ -23,14 +23,15 @@ Given('I open the demo page injecting a JWT', () => {
       const w = win as unknown as TestWindow;
       attachGenerateJWT(w);
       injectedToken = w.generateJWT();
-      (w.document.body as any).token = injectedToken;
+      (w as any).token = injectedToken;
     },
   });
 });
 
 Then('the token property should exist on the body', () => {
   cy.get('body').should(($body) => {
-    expect(($body.get(0) as any).token).to.equal(injectedToken);
+    const bodyToken = ($body.get(0) as any).token;
+    expect(bodyToken).to.equal(injectedToken);
   });
 });
 

--- a/public/script.js
+++ b/public/script.js
@@ -10,10 +10,19 @@ window.generateJWT = function () {
 document.addEventListener('DOMContentLoaded', () => {
   const tokenEl = document.getElementById('token');
   if (tokenEl) {
-    tokenEl.textContent = document.body.token || '';
+    const bodyToken = (document.body || {}).token;
+    const winToken = (window).token;
+    const token = bodyToken || winToken || '';
+    if (winToken && !bodyToken && document.body) {
+      document.body.token = winToken;
+    }
+    tokenEl.textContent = token;
   }
 
   document.getElementById('change')?.addEventListener('click', () => {
-    document.getElementById('title')!.textContent = 'Button Clicked';
+    const titleEl = document.getElementById('title');
+    if (titleEl) {
+      titleEl.textContent = 'Button Clicked';
+    }
   });
 });


### PR DESCRIPTION
## Summary
- fix typo in public script causing SyntaxError
- adjust JWT test to inject token on `window`
- update script to sync token from window to body

## Testing
- `xvfb-run --auto-servernum --server-args="-screen 0 1280x720x24" ./run-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_6842548d9a68832ca8292b73c63d4e88