### PR TITLE
Add centralized test runner script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@ node_modules/
 .tmp/
 .DS_Store
 dist/
-cypress/reports/
+coverage/

--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ npm install
 - `npm run build` – compila o `server.ts` com `tsc` e empacota os arquivos de `src/` com Vite, gerando a pasta `dist/public`.
 - `npm start` – inicia o servidor Node para servir os arquivos de `dist/public`.
 - `npm test` – executa o Cypress em modo headless.
+- `npm run run:tests` – executa o Cypress e gera o relatório consolidado em `coverage/reports.html`.
 - `npm run cy:open` – abre a interface interativa do Cypress.
 - `npm run run:all` – faz a build, inicia o servidor e roda os testes de uma só vez.
-- `npm run merge:reports` – consolida os relatórios em `cypress/reports`.
 
 ## Executando os testes
 
@@ -28,7 +28,7 @@ Após compilar o projeto, inicie o servidor e rode o Cypress:
 ```bash
 npm run build
 npm start        # em um terminal
-npm test         # em outro terminal
+npm run run:tests  # em outro terminal
 ```
 
 Para automatizar o processo acima, utilize:
@@ -37,7 +37,7 @@ Para automatizar o processo acima, utilize:
 npm run run:all
 ```
 
-Ao final um relatório consolidado estará disponível em `cypress/reports/merged-report.html`.
+Ao final um relatório consolidado estará disponível em `coverage/reports.html`.
 
 ## Estrutura do projeto
 

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -20,7 +20,7 @@ export default defineConfig({
     },
     reporter: 'mochawesome',
     reporterOptions: {
-      reportDir: 'cypress/reports',
+      reportDir: 'coverage',
       overwrite: false,
       html: false,
       json: true,

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "cy:run": "cypress run",
     "test": "npm run cy:run",
     "build": "tsc && vite build",
-    "merge:reports": "rm -f cypress/reports/merged-report.json && npx mochawesome-merge cypress/reports/mochawesome_*.json > cypress/reports/merged-report.json && npx marge cypress/reports/merged-report.json -o cypress/reports -f merged-report",
+    "run:tests": "node scripts/run-tests.js",
     "run:all": "./run-all.sh"
   },
   "keywords": [],

--- a/run-all.sh
+++ b/run-all.sh
@@ -20,8 +20,6 @@ trap 'kill $SERVER_PID' EXIT
 # Wait a moment for the server to be ready
 sleep 2
 
-# Run Cypress tests
-npm test
+# Run Cypress tests and generate report
+npm run run:tests
 
-# Merge mochawesome JSON reports
-npm run merge:reports

--- a/scripts/run-tests.js
+++ b/scripts/run-tests.js
@@ -1,0 +1,27 @@
+const { execSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+const reportsDir = path.resolve(__dirname, '../coverage');
+const mergedReport = path.join(reportsDir, 'reports.json');
+
+function run(cmd) {
+  execSync(cmd, { stdio: 'inherit' });
+}
+
+try {
+  if (fs.existsSync(reportsDir)) {
+    fs.rmSync(reportsDir, { recursive: true, force: true });
+  }
+  fs.mkdirSync(reportsDir, { recursive: true });
+
+  run('npx cypress run --headless');
+  run(`npx mochawesome-merge ${reportsDir}/mochawesome_*.json > ${mergedReport}`);
+  run(`npx marge ${mergedReport} -o ${reportsDir} -f reports`);
+
+  console.log('\x1b[32m%s\x1b[0m', '\nRelat\u00f3rio de testes gerado com sucesso!');
+} catch (err) {
+  console.error('Erro ao executar os testes:', err.message);
+  process.exit(1);
+}
+


### PR DESCRIPTION
## Summary
- add `scripts/run-tests.js` for running Cypress and creating consolidated reports
- expose new npm script `run:tests`
- update automation script to use `run:tests`
- document new workflow in README
- centralize test reports under `coverage`

## Testing
- `npm install`
- `npm run run:tests` *(fails: missing Xvfb)*

------
https://chatgpt.com/codex/tasks/task_e_684c49889310832ca05d3b652f9cd122